### PR TITLE
Rename php-webdriver package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
 		"phpunit/phpunit": "^5.3",
-		"facebook/webdriver": "^1.1",
+		"php-webdriver/webdriver": "^1.1",
 		"zf2timo/phpunit-pretty-result-printer": "1.0.0"
     },
     "suggest": {


### PR DESCRIPTION
Php-webdriver package [has been renamed](https://github.com/php-webdriver/php-webdriver/issues/730#issuecomment-575601572) and the original is now marked as abandoned (and will not receive any updates).

```sh
$ composer install
Package facebook/php-webdriver is abandoned, you should avoid using it. Use php-webdriver/webdriver instead.
```